### PR TITLE
Avelino

### DIFF
--- a/open_worm_analysis_toolbox/features/velocity.py
+++ b/open_worm_analysis_toolbox/features/velocity.py
@@ -552,7 +552,7 @@ def get_frames_per_sample(fps, sample_time):
 
     ostensive_sampling_scale = sample_time * fps
 
-    half_scale = round(ostensive_sampling_scale / 2)
+    half_scale = int(round(ostensive_sampling_scale / 2))
     sampling_scale = 2 * half_scale + 1
 
     assert(isinstance(sampling_scale, int) or sampling_scale.is_integer())

--- a/open_worm_analysis_toolbox/utils.py
+++ b/open_worm_analysis_toolbox/utils.py
@@ -507,8 +507,6 @@ def interpolate_with_threshold(array,
 
   """
 
-    assert(threshold is None or threshold >= 0)
-
     if make_copy:
         # Use a new array so we don't modify the original array passed to us
         new_array = np.copy(array)


### PR DESCRIPTION
1) The integer must be forced before.
2) This assertion seems to be unnecessary, the function deals with
cases where threhold is 0 or None.